### PR TITLE
Updated example to make it easier to change between different breakouts

### DIFF
--- a/examples/displayio_ssd1306_simpletest.py
+++ b/examples/displayio_ssd1306_simpletest.py
@@ -11,20 +11,29 @@ import adafruit_displayio_ssd1306
 
 displayio.release_displays()
 
-spi = board.SPI()
-oled_cs = board.D5
-oled_dc = board.D6
-oled_reset = board.D9
+# Use for I2C
+i2c = board.I2C()
+display_bus = displayio.I2CDisplay(i2c, device_address=0x3c)
 
-display_bus = displayio.FourWire(spi, command=oled_dc, chip_select=oled_cs,
-                                 reset=oled_reset, baudrate=1000000)
-display = adafruit_displayio_ssd1306.SSD1306(display_bus, width=128, height=64)
+# Use for SPI
+#spi = board.SPI()
+#oled_cs = board.D5
+#oled_dc = board.D6
+#oled_reset = board.D9
+#display_bus = displayio.FourWire(spi, command=oled_dc, chip_select=oled_cs,
+#                                 reset=oled_reset, baudrate=1000000)
+
+WIDTH = 128
+HEIGHT = 32     # Change to 64 if needed
+BORDER = 5
+
+display = adafruit_displayio_ssd1306.SSD1306(display_bus, width=WIDTH, height=HEIGHT)
 
 # Make the display context
 splash = displayio.Group(max_size=10)
 display.show(splash)
 
-color_bitmap = displayio.Bitmap(128, 64, 1)
+color_bitmap = displayio.Bitmap(WIDTH, HEIGHT, 1)
 color_palette = displayio.Palette(1)
 color_palette[0] = 0xFFFFFF # White
 
@@ -34,17 +43,17 @@ bg_sprite = displayio.TileGrid(color_bitmap,
 splash.append(bg_sprite)
 
 # Draw a smaller inner rectangle
-inner_bitmap = displayio.Bitmap(118, 54, 1)
+inner_bitmap = displayio.Bitmap(WIDTH-BORDER*2, HEIGHT-BORDER*2, 1)
 inner_palette = displayio.Palette(1)
 inner_palette[0] = 0x000000 # Black
 inner_sprite = displayio.TileGrid(inner_bitmap,
                                   pixel_shader=inner_palette,
-                                  x=5, y=5)
+                                  x=BORDER, y=BORDER)
 splash.append(inner_sprite)
 
 # Draw a label
 text = "Hello World!"
-text_area = label.Label(terminalio.FONT, text=text, color=0xFFFFFF, x=28, y=32)
+text_area = label.Label(terminalio.FONT, text=text, color=0xFFFFFF, x=28, y=HEIGHT//2-1)
 splash.append(text_area)
 
 while True:


### PR DESCRIPTION
This adds a section for I2C (and defaults to that) as well as making WIDTH, HEIGHT, and BORDER variables to make changing it much easier between display sizes.