### PR TITLE
Implement SSD1306 sleep/wake functionality

### DIFF
--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -48,7 +48,7 @@ _INIT_SEQUENCE = (
     b"\xda\x01\x12"  # Set com configuration
     b"\xdb\x01\x40"  # Set vcom configuration
     b"\x8d\x01\x14"  # Enable charge pump
-    b"\xAF\x00\x00"  # DISPLAY_ON
+    b"\xAF\x00"  # DISPLAY_ON
 )
 
 # pylint: disable=too-few-public-methods

--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -51,7 +51,7 @@ _INIT_SEQUENCE = (
     b"\xAF\x00"  # DISPLAY_ON
 )
 
-# pylint: disable=too-few-public-methods
+
 class SSD1306(displayio.Display):
     """SSD1306 driver"""
 
@@ -78,3 +78,33 @@ class SSD1306(displayio.Display):
             brightness_command=0x81,
             single_byte_bounds=True,
         )
+        self._is_awake = True  # Display starts in active state (_INIT_SEQUENCE)
+
+    @property
+    def is_awake(self):
+        """
+        The power state of the display. (read-only)
+
+        True if the display is active, False if in sleep mode.
+        """
+        return self._is_awake
+
+    def sleep(self):
+        """
+        Put display into sleep mode
+
+        Display uses < 10uA in sleep mode
+        Display remembers display data and operation mode active prior to sleeping
+        MP can access (update) the built-in display RAM
+        """
+        if self._is_awake:
+            self.bus.send(int(0xAE), "")  # 0xAE = display off, sleep mode
+            self._is_awake = False
+
+    def wake(self):
+        """
+        Wake display from sleep mode
+        """
+        if not self._is_awake:
+            self.bus.send(int(0xAF), "")  # 0xAF = display on
+            self._is_awake = True


### PR DESCRIPTION
Add `sleep()` and `wake()` methods and an `is_awake` property to allow users to put the display into a power-saving mode.  Uses the bus object passed to the `SSD1306` class at initialization to write to the device.  Commands for entering and exiting sleep mode derived from the [SSD1306 datasheet](https://www.electronicscomp.com/datasheet/ssd1306-datasheet.pdf).

Tested on a [Monochrome 1.3" 128x64 OLED graphic display](https://www.adafruit.com/product/938)