### PR TITLE
Remove max_size parameter

### DIFF
--- a/examples/displayio_ssd1306_featherwing.py
+++ b/examples/displayio_ssd1306_featherwing.py
@@ -19,7 +19,7 @@ display_bus = displayio.I2CDisplay(i2c, device_address=0x3C)
 display = adafruit_displayio_ssd1306.SSD1306(display_bus, width=128, height=32)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(128, 32, 1)

--- a/examples/displayio_ssd1306_simpletest.py
+++ b/examples/displayio_ssd1306_simpletest.py
@@ -34,7 +34,7 @@ BORDER = 5
 display = adafruit_displayio_ssd1306.SSD1306(display_bus, width=WIDTH, height=HEIGHT)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(WIDTH, HEIGHT, 1)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

I don't have a SSD1306 display to test with.