### PR TITLE
Enable uploading of the driver to PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Introduction
 ============
 
-.. image:: https://readthedocs.org/projects/adafruit-circuitpython-displayio_ssd1306/badge/?version=latest
+.. image:: https://readthedocs.org/projects/adafruit-circuitpython-displayio-ssd1306/badge/?version=latest
     :target: https://circuitpython.readthedocs.io/projects/displayio_ssd1306/en/latest/
     :alt: Documentation Status
 
@@ -15,14 +15,15 @@ Introduction
 
 DisplayIO driver for SSD1306 monochrome displays. DisplayIO drivers enable terminal output
 
-For the framebuf based driver see `Adafruit CircuitPython SSD1306 <https://github.com/adafruit/Adafruit_CircuitPython_SSD1306/>`_.
+For the framebuf based driver see
+`Adafruit CircuitPython SSD1306 <https://github.com/adafruit/Adafruit_CircuitPython_SSD1306/>`_.
 
 
 Dependencies
 =============
 This driver depends on:
 
-* `Adafruit CircuitPython Version 5+ <https://github.com/adafruit/circuitpython>`_
+* `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
@@ -30,11 +31,9 @@ This is easily achieved by downloading
 
 Installing from PyPI
 =====================
-.. note:: This library is not available on PyPI yet. Install documentation is included
-   as a standard element. Stay tuned for PyPI availability!
 
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
-PyPI <https://pypi.org/project/adafruit-circuitpython-displayio_ssd1306/>`_. To install for current user:
+PyPI <https://pypi.org/project/adafruit-circuitpython-displayio-ssd1306/>`_. To install for current user:
 
 .. code-block:: shell
 
@@ -86,4 +85,5 @@ before contributing to help this project stay welcoming.
 Documentation
 =============
 
-For information on building library documentation, please check out `this guide <https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-our-docs-on-readthedocs#sphinx-5-1>`_.
+For information on building library documentation, please check out `this guide
+<https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-our-docs-on-readthedocs#sphinx-5-1>`_.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""A setuptools based setup module.
+
+See:
+https://packaging.python.org/en/latest/distributing.html
+https://github.com/pypa/sampleproject
+"""
+
+from setuptools import setup, find_packages
+
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, "README.rst"), encoding="utf-8") as f:
+    long_description = f.read()
+
+setup(
+    name="adafruit-circuitpython-displayio-ssd1306",
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
+    description="DisplayIO driver for SSD1306 monochrome displays",
+    long_description=long_description,
+    long_description_content_type="text/x-rst",
+    # The project's main homepage.
+    url="https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_SSD1306",
+    # Author details
+    author="Adafruit Industries",
+    author_email="circuitpython@adafruit.com",
+    install_requires=["Adafruit-Blinka"],
+    # Choose your license
+    license="MIT",
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: System :: Hardware",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+    ],
+    # What does your project relate to?
+    keywords="adafruit blinka circuitpython micropython displayio_ssd1306 displayio ssd1306 "
+    "oled",
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    # TODO: IF LIBRARY FILES ARE A PACKAGE FOLDER,
+    #       CHANGE `py_modules=['...']` TO `packages=['...']`
+    py_modules=["adafruit_displayio_ssd1306"],
+)

--- a/setup.py.disabled
+++ b/setup.py.disabled
@@ -1,8 +1,0 @@
-# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
-#
-# SPDX-License-Identifier: MIT
-
-"""
-This library is not deployed to PyPI. It is either a board-specific helper library, or
-does not make sense for use on or is incompatible with single board computers and Linux.
-"""


### PR DESCRIPTION
This allows the driver to used with Blinka
Ref: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/336