### PR TITLE
Fix faulty type annotation

### DIFF
--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -68,7 +68,7 @@ class SSD1306(displayio.Display):
     """
 
     def __init__(
-        self, bus: Union[displayio.Fourwire, displayio.I2CDisplay], **kwargs
+        self, bus: Union[displayio.FourWire, displayio.I2CDisplay], **kwargs
     ) -> None:
         # Patch the init sequence for 32 pixel high displays.
         init_sequence = bytearray(_INIT_SEQUENCE)


### PR DESCRIPTION
Fixes #28 which was caused by a faulty type annotation in `__init__()`