### PR TITLE
Add support for 0.49'' 64 x 32

### DIFF
--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -80,7 +80,7 @@ class SSD1306(displayio.Display):
             height = kwargs["width"]
             width = kwargs["height"]
         init_sequence[16] = height - 1  # patch mux ratio
-        if height == 32 and width == 64:  # FIX ME
+        if height == 32 and width == 64:  # Make sure this only apply to that resolution
             init_sequence[16] = 64 - 1  # FORCED for 64x32 because it fail with formula
         if height in (32, 16) and width != 64:
             init_sequence[25] = 0x02  # patch com configuration

--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -21,6 +21,8 @@ Implementation Notes
 * `Monochrome 0.96" 128x64 OLED graphic display <https://www.adafruit.com/product/326>`_
 * `Monochrome 128x32 SPI OLED graphic display <https://www.adafruit.com/product/661>`_
 * `Adafruit FeatherWing OLED - 128x32 OLED <https://www.adafruit.com/product/2900>`_
+* Monochrome 0.49" 64x32 I2C OLED graphic display
+* Might work on other sub-128 width display: Dots 72x40, 64x48, 96x16 
 
 **Software and Dependencies:**
 
@@ -73,15 +75,22 @@ class SSD1306(displayio.Display):
         # Patch the init sequence for 32 pixel high displays.
         init_sequence = bytearray(_INIT_SEQUENCE)
         height = kwargs["height"]
+        width = kwargs["width"]
         if "rotation" in kwargs and kwargs["rotation"] % 180 != 0:
             height = kwargs["width"]
+            width = kwargs["height"]
         init_sequence[16] = height - 1  # patch mux ratio
-        if kwargs["height"] == 32:
+        if height == 32 and width == 64: # FIX ME
+            init_sequence[16] = 64 - 1  # FORCED for 64x32 because it fail with formula
+        if (height == 32 or height == 16) and (width != 64):
             init_sequence[25] = 0x02  # patch com configuration
+        col_offset = 0 if width == 128 else (128 - width) // 2 # https://github.com/micropython/micropython/pull/7411
         super().__init__(
             bus,
             init_sequence,
             **kwargs,
+            colstart=col_offset,
+            rowstart=col_offset,
             color_depth=1,
             grayscale=True,
             pixels_in_byte_share_row=False,

--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -80,11 +80,13 @@ class SSD1306(displayio.Display):
             height = kwargs["width"]
             width = kwargs["height"]
         init_sequence[16] = height - 1  # patch mux ratio
-        if height == 32 and width == 64: # FIX ME
+        if height == 32 and width == 64:  # FIX ME
             init_sequence[16] = 64 - 1  # FORCED for 64x32 because it fail with formula
         if (height == 32 or height == 16) and (width != 64):
             init_sequence[25] = 0x02  # patch com configuration
-        col_offset = 0 if width == 128 else (128 - width) // 2 # https://github.com/micropython/micropython/pull/7411
+        col_offset = (
+            0 if width == 128 else (128 - width) // 2
+        )  # https://github.com/micropython/micropython/pull/7411
         super().__init__(
             bus,
             init_sequence,

--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -22,7 +22,7 @@ Implementation Notes
 * `Monochrome 128x32 SPI OLED graphic display <https://www.adafruit.com/product/661>`_
 * `Adafruit FeatherWing OLED - 128x32 OLED <https://www.adafruit.com/product/2900>`_
 * Monochrome 0.49" 64x32 I2C OLED graphic display
-* Might work on other sub-128 width display: Dots 72x40, 64x48, 96x16 
+* Might work on other sub-128 width display: Dots 72x40, 64x48, 96x16
 
 **Software and Dependencies:**
 
@@ -82,7 +82,7 @@ class SSD1306(displayio.Display):
         init_sequence[16] = height - 1  # patch mux ratio
         if height == 32 and width == 64:  # FIX ME
             init_sequence[16] = 64 - 1  # FORCED for 64x32 because it fail with formula
-        if (height == 32 or height == 16) and (width != 64):
+        if height in (32, 16) and width != 64:
             init_sequence[25] = 0x02  # patch com configuration
         col_offset = (
             0 if width == 128 else (128 - width) // 2

--- a/examples/displayio_ssd1306_64x32_simpletest.py
+++ b/examples/displayio_ssd1306_64x32_simpletest.py
@@ -40,16 +40,16 @@ inner_palette[0] = 0x000000  # Black
 inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=1, y=1)
 splash.append(inner_sprite)
 
-text = "Hello"
-text_area = label.Label(terminalio.FONT, text=text, color=0xFFFFFF, x=2, y=6)
+TEXT1 = "Hello"
+text_area = label.Label(terminalio.FONT, text=TEXT1, color=0xFFFFFF, x=2, y=6)
 splash.append(text_area)
 
-text = "World"
-text_area = label.Label(terminalio.FONT, text=text, color=0xFFFFFF, x=32, y=15)
+TEXT2 = "World"
+text_area = label.Label(terminalio.FONT, text=TEXT2, color=0xFFFFFF, x=32, y=15)
 splash.append(text_area)
 
-text = "9876543210"
-text_area = label.Label(terminalio.FONT, text=text, color=0xFFFFFF, x=2, y=24)
+TEXT3 = "9876543210"
+text_area = label.Label(terminalio.FONT, text=TEXT3, color=0xFFFFFF, x=2, y=24)
 splash.append(text_area)
 
 while True:

--- a/examples/displayio_ssd1306_64x32_simpletest.py
+++ b/examples/displayio_ssd1306_64x32_simpletest.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2022 David Glaude (based on 2021 ladyada for Adafruit Industries)
+# SPDX-License-Identifier: MIT
+
+"""
+This test will initialize the display using displayio and draw a solid white
+background, a smaller black rectangle, and some white text.
+Customized version of displayio_ssd1306_simpletest.py for 64x32
+"""
+
+import board
+import displayio
+import terminalio
+from adafruit_display_text import label
+import adafruit_displayio_ssd1306
+
+displayio.release_displays()
+
+i2c = board.I2C()  # uses board.SCL and board.SDA
+# i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
+
+display_bus = displayio.I2CDisplay(i2c, device_address=0x3C)
+display = adafruit_displayio_ssd1306.SSD1306(display_bus, width=64, height=32)
+
+# Make the display context
+splash = displayio.Group()
+display.show(splash)
+
+color_bitmap = displayio.Bitmap(64, 32, 1)
+color_palette = displayio.Palette(1)
+color_palette[0] = 0xFFFFFF  # White
+
+bg_sprite = displayio.TileGrid(color_bitmap, pixel_shader=color_palette, x=0, y=0)
+splash.append(bg_sprite)
+
+## Draw a smaller inner rectangle
+inner_bitmap = displayio.Bitmap(62, 30, 1)
+inner_palette = displayio.Palette(1)
+inner_palette[0] = 0x000000  # Black
+
+inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=1, y=1)
+splash.append(inner_sprite)
+
+text = "Hello"
+text_area = label.Label( terminalio.FONT, text=text, color=0xFFFFFF, x=2, y=6)
+splash.append(text_area)
+
+text = "World"
+text_area = label.Label( terminalio.FONT, text=text, color=0xFFFFFF, x=32, y=15)
+splash.append(text_area)
+
+text = "9876543210"
+text_area = label.Label( terminalio.FONT, text=text, color=0xFFFFFF, x=2, y=24)
+splash.append(text_area)
+
+while True:
+    pass

--- a/examples/displayio_ssd1306_64x32_simpletest.py
+++ b/examples/displayio_ssd1306_64x32_simpletest.py
@@ -41,15 +41,15 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=1,
 splash.append(inner_sprite)
 
 text = "Hello"
-text_area = label.Label( terminalio.FONT, text=text, color=0xFFFFFF, x=2, y=6)
+text_area = label.Label(terminalio.FONT, text=text, color=0xFFFFFF, x=2, y=6)
 splash.append(text_area)
 
 text = "World"
-text_area = label.Label( terminalio.FONT, text=text, color=0xFFFFFF, x=32, y=15)
+text_area = label.Label(terminalio.FONT, text=text, color=0xFFFFFF, x=32, y=15)
 splash.append(text_area)
 
 text = "9876543210"
-text_area = label.Label( terminalio.FONT, text=text, color=0xFFFFFF, x=2, y=24)
+text_area = label.Label(terminalio.FONT, text=text, color=0xFFFFFF, x=2, y=24)
 splash.append(text_area)
 
 while True:


### PR DESCRIPTION
Trying to follow all the discussion on #20 and the work of @adamcandy on the non DisplayIO library: https://github.com/adafruit/Adafruit_CircuitPython_SSD1306

Tested on "OLED 0.49 Shield V1.0.0 for LOLIN (WEMOS) D1 mini D32 0.49" inch 64x32 IIC I2C"

I believe this would require more testing on all of the Adafruit 128x display (to avoid regression).
And it could be tested on other small display: Dots 72x40, 64x48 and 96x16.

I am not 100% on the logic, it might fail too when the screen is rotated.

The simpletest is optional, I just feel it help do testing.