### PR TITLE
9.x compatibility in examples

### DIFF
--- a/examples/displayio_ssd1306_64x32_simpletest.py
+++ b/examples/displayio_ssd1306_64x32_simpletest.py
@@ -9,6 +9,14 @@ Customized version of displayio_ssd1306_simpletest.py for 64x32
 
 import board
 import displayio
+
+# Compatibility with both CircuitPython 8.x.x and 9.x.x.
+# Remove after 8.x.x is no longer a supported release.
+try:
+    from i2cdisplaybus import I2CDisplayBus
+except ImportError:
+    from displayio import I2CDisplay as I2CDisplayBus
+
 import terminalio
 from adafruit_display_text import label
 import adafruit_displayio_ssd1306
@@ -18,7 +26,7 @@ displayio.release_displays()
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
 
-display_bus = displayio.I2CDisplay(i2c, device_address=0x3C)
+display_bus = I2CDisplayBus(i2c, device_address=0x3C)
 display = adafruit_displayio_ssd1306.SSD1306(display_bus, width=64, height=32)
 
 # Make the display context

--- a/examples/displayio_ssd1306_featherwing.py
+++ b/examples/displayio_ssd1306_featherwing.py
@@ -8,6 +8,14 @@ background, a smaller black rectangle, and some white text.
 
 import board
 import displayio
+
+# Compatibility with both CircuitPython 8.x.x and 9.x.x.
+# Remove after 8.x.x is no longer a supported release.
+try:
+    from i2cdisplaybus import I2CDisplayBus
+except ImportError:
+    from displayio import I2CDisplay as I2CDisplayBus
+
 import terminalio
 from adafruit_display_text import label
 import adafruit_displayio_ssd1306
@@ -16,7 +24,7 @@ displayio.release_displays()
 
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-display_bus = displayio.I2CDisplay(i2c, device_address=0x3C)
+display_bus = I2CDisplayBus(i2c, device_address=0x3C)
 display = adafruit_displayio_ssd1306.SSD1306(display_bus, width=128, height=32)
 
 # Make the display context

--- a/examples/displayio_ssd1306_picowbell_tempsensor.py
+++ b/examples/displayio_ssd1306_picowbell_tempsensor.py
@@ -6,6 +6,14 @@
 import time
 import board
 import displayio
+
+# Compatibility with both CircuitPython 8.x.x and 9.x.x.
+# Remove after 8.x.x is no longer a supported release.
+try:
+    from i2cdisplaybus import I2CDisplayBus
+except ImportError:
+    from displayio import I2CDisplay as I2CDisplayBus
+
 import busio
 import terminalio
 from adafruit_display_text import label
@@ -29,7 +37,7 @@ ssd_width = 128
 ssd_height = 32
 
 # Ensure the physical address of your SSD1306 is set here:
-ssd_bus = displayio.I2CDisplay(i2c0, device_address=0x3C)
+ssd_bus = I2CDisplayBus(i2c0, device_address=0x3C)
 display = ssd1306.SSD1306(ssd_bus, width=ssd_width, height=ssd_height)
 
 # Manually set your sea_level_pressure to your area

--- a/examples/displayio_ssd1306_simpletest.py
+++ b/examples/displayio_ssd1306_simpletest.py
@@ -8,6 +8,14 @@ background, a smaller black rectangle, and some white text.
 
 import board
 import displayio
+
+# Compatibility with both CircuitPython 8.x.x and 9.x.x.
+# Remove after 8.x.x is no longer a supported release.
+try:
+    from i2cdisplaybus import I2CDisplayBus
+except ImportError:
+    from displayio import I2CDisplay as I2CDisplayBus
+
 import terminalio
 from adafruit_display_text import label
 import adafruit_displayio_ssd1306
@@ -19,7 +27,7 @@ oled_reset = board.D9
 # Use for I2C
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-display_bus = displayio.I2CDisplay(i2c, device_address=0x3C, reset=oled_reset)
+display_bus = I2CDisplayBus(i2c, device_address=0x3C, reset=oled_reset)
 
 # Use for SPI
 # spi = board.SPI()

--- a/examples/displayio_ssd1306_simpletest.py
+++ b/examples/displayio_ssd1306_simpletest.py
@@ -13,8 +13,12 @@ import displayio
 # Remove after 8.x.x is no longer a supported release.
 try:
     from i2cdisplaybus import I2CDisplayBus
+
+    # from fourwire import FourWire
 except ImportError:
     from displayio import I2CDisplay as I2CDisplayBus
+
+    # from displayio import FourWire
 
 import terminalio
 from adafruit_display_text import label
@@ -33,7 +37,7 @@ display_bus = I2CDisplayBus(i2c, device_address=0x3C, reset=oled_reset)
 # spi = board.SPI()
 # oled_cs = board.D5
 # oled_dc = board.D6
-# display_bus = displayio.FourWire(spi, command=oled_dc, chip_select=oled_cs,
+# display_bus = FourWire(spi, command=oled_dc, chip_select=oled_cs,
 #                                 reset=oled_reset, baudrate=1000000)
 
 WIDTH = 128

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
+Adafruit-Blinka-Displayio


### PR DESCRIPTION
The main library was updated previously but examples were still 8.x style this upates them to be compatible for 9.x