### PR TITLE
Fix sleep/wake, again

### DIFF
--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -32,11 +32,13 @@ Implementation Notes
 
 """
 try:
+    _Blinka = True
     from typing import Union
     from busdisplay import BusDisplay
     from fourwire import FourWire
     from i2cdisplaybus import I2CDisplayBus
 except ImportError:
+    _Blinka = False
     from displayio import FourWire
     from displayio import I2CDisplay as I2CDisplayBus
     from displayio import Display as BusDisplay
@@ -127,7 +129,10 @@ class SSD1306(BusDisplay):
         active prior to sleeping. MP can access (update) the built-in display RAM.
         """
         if self._is_awake:
-            self.bus.send(0xAE, bytearray())  # 0xAE = display off, sleep mode
+            if _Blinka:
+                self.bus.send(0xAE, [])  # 0xAE = display off, sleep mode
+            else:
+                self.bus.send(0xAE, b"")  # 0xAE = display off, sleep mode
             self._is_awake = False
 
     def wake(self) -> None:
@@ -135,5 +140,8 @@ class SSD1306(BusDisplay):
         Wake display from sleep mode
         """
         if not self._is_awake:
-            self.bus.send(0xAF, bytearray())  # 0xAF = display on
+            if _Blinka:
+                self.bus.send(0xAF, [])  # 0xAF = display on
+            else:
+                self.bus.send(0xAF, b"")  # 0xAF = display on
             self._is_awake = True

--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -32,13 +32,13 @@ Implementation Notes
 
 """
 try:
-    _Blinka = True
+    __blinka__ = True
     from typing import Union
     from busdisplay import BusDisplay
     from fourwire import FourWire
     from i2cdisplaybus import I2CDisplayBus
 except ImportError:
-    _Blinka = False
+    __blinka__ = False
     from displayio import FourWire
     from displayio import I2CDisplay as I2CDisplayBus
     from displayio import Display as BusDisplay
@@ -129,7 +129,7 @@ class SSD1306(BusDisplay):
         active prior to sleeping. MP can access (update) the built-in display RAM.
         """
         if self._is_awake:
-            if _Blinka:
+            if __blinka__:
                 self.bus.send(0xAE, [])  # 0xAE = display off, sleep mode
             else:
                 self.bus.send(0xAE, b"")  # 0xAE = display off, sleep mode
@@ -140,7 +140,7 @@ class SSD1306(BusDisplay):
         Wake display from sleep mode
         """
         if not self._is_awake:
-            if _Blinka:
+            if __blinka__:
                 self.bus.send(0xAF, [])  # 0xAF = display on
             else:
                 self.bus.send(0xAF, b"")  # 0xAF = display on

--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -127,7 +127,7 @@ class SSD1306(BusDisplay):
         active prior to sleeping. MP can access (update) the built-in display RAM.
         """
         if self._is_awake:
-            self.bus.send(0xAE, [])  # 0xAE = display off, sleep mode
+            self.bus.send(0xAE, bytearray())  # 0xAE = display off, sleep mode
             self._is_awake = False
 
     def wake(self) -> None:
@@ -135,5 +135,5 @@ class SSD1306(BusDisplay):
         Wake display from sleep mode
         """
         if not self._is_awake:
-            self.bus.send(0xAF, [])  # 0xAF = display on
+            self.bus.send(0xAF, bytearray())  # 0xAF = display on
             self._is_awake = True


### PR DESCRIPTION
Not sure about `wake()`, but `sleep()` were throwing `TypeError: object with buffer protocol required` at me.