### PR TITLE
Revert "Fix sleep/wake not working."

### DIFF
--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -127,7 +127,7 @@ class SSD1306(BusDisplay):
         active prior to sleeping. MP can access (update) the built-in display RAM.
         """
         if self._is_awake:
-            self.bus.send(0xAE, [])  # 0xAE = display off, sleep mode
+            self.bus.send(0xAE, b"")  # 0xAE = display off, sleep mode
             self._is_awake = False
 
     def wake(self) -> None:
@@ -135,5 +135,5 @@ class SSD1306(BusDisplay):
         Wake display from sleep mode
         """
         if not self._is_awake:
-            self.bus.send(0xAF, [])  # 0xAF = display on
+            self.bus.send(0xAF, b"")  # 0xAF = display on
             self._is_awake = True


### PR DESCRIPTION
This reverts commit c923dc238259660e869a7282b05f31098120ea44.

As noted in #44, #43 broke implementations on micro-controllers, so this reverts that change. As a result, #47 is being opened and linked to a bug in the Blinka I2C implementation.