### PR TITLE
Add support for 72x40 SSD1306B

### DIFF
--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -23,7 +23,8 @@ Implementation Notes
 * `Adafruit FeatherWing OLED - 128x32 OLED <https://www.adafruit.com/product/2900>`_
 * Monochrome 0.49" 64x32 I2C OLED graphic display
 * Monochrome 0.66" 64x48 I2C OLED graphic display (eg https://www.amazon.com/gp/product/B07QF7QK6P)
-* Miniature 0.42" OLED 72x40 Display with Resin Lens (https://www.tindie.com/products/questwise-ventures/miniature-042-oled-72x40-display-with-resin-lens/)
+* Miniature 0.42" OLED 72x40 Display with Resin Lens
+  * https://tindie.com/products/questwise-ventures/miniature-042-oled-72x40-display-with-resin-lens
 * Might work on other sub-128 width display: Dots 72x40, 64x48, 96x16
 
 **Software and Dependencies:**

--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -23,6 +23,7 @@ Implementation Notes
 * `Adafruit FeatherWing OLED - 128x32 OLED <https://www.adafruit.com/product/2900>`_
 * Monochrome 0.49" 64x32 I2C OLED graphic display
 * Monochrome 0.66" 64x48 I2C OLED graphic display (eg https://www.amazon.com/gp/product/B07QF7QK6P)
+* Miniature 0.42" OLED 72x40 Display with Resin Lens (https://www.tindie.com/products/questwise-ventures/miniature-042-oled-72x40-display-with-resin-lens/)
 * Might work on other sub-128 width display: Dots 72x40, 64x48, 96x16
 
 **Software and Dependencies:**
@@ -91,6 +92,24 @@ class SSD1306(BusDisplay):
         row_offset = (
             col_offset if (kwargs["height"] != 48 or kwargs["width"] != 64) else 0
         )  # fix for 0.66" 64x48 OLED
+
+        # for 72x40
+        if kwargs["height"] == 40 and kwargs["width"] == 72:
+            col_offset = 28
+            row_offset = 0
+
+            # add Internal IREF Setting for the 0.42 OLED as per
+            # https://github.com/olikraus/u8g2/issues/1047 and
+            # SSD1306B rev 1.1 datasheet at
+            # https://www.buydisplay.com/download/ic/SSD1306.pdf
+            seq_length = len(init_sequence) - 2
+            init_sequence[seq_length:seq_length] = bytearray(b"\xad\x01\x30")
+
+            if "rotation" in kwargs and kwargs["rotation"] % 180 != 0:
+                init_sequence[16] = kwargs["height"] - 1
+                kwargs["height"] = height
+                kwargs["width"] = width
+
         super().__init__(
             bus,
             init_sequence,

--- a/adafruit_displayio_ssd1306.py
+++ b/adafruit_displayio_ssd1306.py
@@ -89,13 +89,21 @@ class SSD1306(BusDisplay):
         col_offset = (
             0 if width == 128 else (128 - width) // 2
         )  # https://github.com/micropython/micropython/pull/7411
-        row_offset = (
-            col_offset if (kwargs["height"] != 48 or kwargs["width"] != 64) else 0
-        )  # fix for 0.66" 64x48 OLED
+        row_offset = col_offset
+
+        # for 64x48
+        if kwargs["height"] == 48 and kwargs["width"] == 64:
+            col_offset = (128 - kwargs["width"]) // 2
+            row_offset = 0
+
+            if "rotation" in kwargs and kwargs["rotation"] % 180 != 0:
+                init_sequence[16] = kwargs["height"] - 1
+                kwargs["height"] = height
+                kwargs["width"] = width
 
         # for 72x40
         if kwargs["height"] == 40 and kwargs["width"] == 72:
-            col_offset = 28
+            col_offset = (128 - kwargs["width"]) // 2
             row_offset = 0
 
             # add Internal IREF Setting for the 0.42 OLED as per


### PR DESCRIPTION
This adds support for the  tiny 72x40 found at https://www.tindie.com/products/questwise-ventures/miniature-042-oled-72x40-display-with-resin-lens/; I suspect it will work with others of this size, but its the only one I've currently got to test.

Supports all 4 rotations.

Pre-commit shows that my comment giving the URL for the tested module is too long... what's the policy or change I should make here?

~~~sh
% pre-commit run --all-files                                             U main
black....................................................................Passed
reuse....................................................................Passed
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
pylint (library code)....................................................Failed
- hook id: pylint
- exit code: 16

************* Module adafruit_displayio_ssd1306
adafruit_displayio_ssd1306.py:26:0: C0301: Line too long (155/100) (line-too-long)

------------------------------------------------------------------
Your code has been rated at 9.79/10 (previous run: 9.79/10, +0.00)

pylint (example code)....................................................Passed
pylint (test code)...................................(no files to check)Skipped
~~~